### PR TITLE
remove big.int atlas

### DIFF
--- a/node.go
+++ b/node.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/big"
 	"strconv"
 	"strings"
 
@@ -56,6 +57,19 @@ var cidAtlasEntry = atlas.BuildEntry(cid.Cid{}).
 	TransformUnmarshal(atlas.MakeUnmarshalTransformFunc(
 		castBytesToCid,
 	)).
+	Complete()
+
+// BigIntAtlasEntry gives a reasonable default encoding for big.Int.
+// It is not included in the entries by default.
+var BigIntAtlasEntry = atlas.BuildEntry(big.Int{}).Transform().
+	TransformMarshal(atlas.MakeMarshalTransformFunc(
+		func(i big.Int) ([]byte, error) {
+			return i.Bytes(), nil
+		})).
+	TransformUnmarshal(atlas.MakeUnmarshalTransformFunc(
+		func(x []byte) (big.Int, error) {
+			return *big.NewInt(0).SetBytes(x), nil
+		})).
 	Complete()
 
 var cborAtlas atlas.Atlas

--- a/node.go
+++ b/node.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/big"
 	"strconv"
 	"strings"
 
@@ -59,23 +58,12 @@ var cidAtlasEntry = atlas.BuildEntry(cid.Cid{}).
 	)).
 	Complete()
 
-var bigIntAtlasEntry = atlas.BuildEntry(big.Int{}).Transform().
-	TransformMarshal(atlas.MakeMarshalTransformFunc(
-		func(i big.Int) ([]byte, error) {
-			return i.Bytes(), nil
-		})).
-	TransformUnmarshal(atlas.MakeUnmarshalTransformFunc(
-		func(x []byte) (big.Int, error) {
-			return *big.NewInt(0).SetBytes(x), nil
-		})).
-	Complete()
-
 var cborAtlas atlas.Atlas
 var cborSortingMode = atlas.KeySortMode_RFC7049
-var atlasEntries = []*atlas.AtlasEntry{cidAtlasEntry, bigIntAtlasEntry}
+var atlasEntries = []*atlas.AtlasEntry{cidAtlasEntry}
 
 func init() {
-	cborAtlas = atlas.MustBuild(cidAtlasEntry, bigIntAtlasEntry).WithMapMorphism(atlas.MapMorphism{atlas.KeySortMode_RFC7049})
+	cborAtlas = atlas.MustBuild(cidAtlasEntry).WithMapMorphism(atlas.MapMorphism{atlas.KeySortMode_RFC7049})
 }
 
 // RegisterCborType allows to register a custom cbor type

--- a/node_test.go
+++ b/node_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math"
+	"math/big"
 	"sort"
 	"strings"
 	"testing"
@@ -534,4 +535,73 @@ func TestCanonicalStructEncoding(t *testing.T) {
 	if !bytes.Equal(expraw, m.RawData()) {
 		t.Fatal("not canonical")
 	}
+}
+
+type TestMe struct {
+	Hello *big.Int
+	World big.Int
+	Hi    int
+}
+
+func TestBigIntRoundtrip(t *testing.T) {
+	RegisterCborType(BigIntAtlasEntry)
+	RegisterCborType(TestMe{})
+
+	one := TestMe{
+		Hello: big.NewInt(100),
+		World: *big.NewInt(99),
+	}
+
+	bytes, err := DumpObject(&one)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var oneBack TestMe
+	if err := DecodeInto(bytes, &oneBack); err != nil {
+		t.Fatal(err)
+	}
+
+	if one.Hello.Cmp(oneBack.Hello) != 0 {
+		t.Fatal("failed to roundtrip *big.Int")
+	}
+
+	if one.World.Cmp(&oneBack.World) != 0 {
+		t.Fatal("failed to roundtrip big.Int")
+	}
+
+	list := map[string]*TestMe{
+		"hello": &TestMe{Hello: big.NewInt(10), World: *big.NewInt(101), Hi: 1},
+		"world": &TestMe{Hello: big.NewInt(9), World: *big.NewInt(901), Hi: 3},
+	}
+
+	bytes, err = DumpObject(list)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var listBack map[string]*TestMe
+	if err := DecodeInto(bytes, &listBack); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log(listBack["hello"])
+	t.Log(listBack["world"])
+
+	if list["hello"].Hello.Cmp(listBack["hello"].Hello) != 0 {
+		t.Fatalf("failed to roundtrip *big.Int: %s != %s", list["hello"].Hello, listBack["hello"].Hello)
+	}
+
+	if list["hello"].World.Cmp(&listBack["hello"].World) != 0 {
+		t.Fatalf("failed to roundtrip big.Int: %s != %s", &list["hello"].World, &listBack["hello"].World)
+	}
+
+	if list["world"].Hello.Cmp(listBack["world"].Hello) != 0 {
+		t.Fatalf("failed to roundtrip *big.Int: %s != %s", list["world"].Hello, listBack["world"].Hello)
+	}
+
+	if list["world"].World.Cmp(&listBack["world"].World) != 0 {
+		t.Fatalf("failed to roundtrip big.Int: %s != %s", &list["world"].World, &listBack["world"].World)
+	}
+
 }

--- a/node_test.go
+++ b/node_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math"
-	"math/big"
 	"sort"
 	"strings"
 	"testing"
@@ -535,72 +534,4 @@ func TestCanonicalStructEncoding(t *testing.T) {
 	if !bytes.Equal(expraw, m.RawData()) {
 		t.Fatal("not canonical")
 	}
-}
-
-type TestMe struct {
-	Hello *big.Int
-	World big.Int
-	Hi    int
-}
-
-func TestBigIntRoundtrip(t *testing.T) {
-	RegisterCborType(TestMe{})
-
-	one := TestMe{
-		Hello: big.NewInt(100),
-		World: *big.NewInt(99),
-	}
-
-	bytes, err := DumpObject(&one)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var oneBack TestMe
-	if err := DecodeInto(bytes, &oneBack); err != nil {
-		t.Fatal(err)
-	}
-
-	if one.Hello.Cmp(oneBack.Hello) != 0 {
-		t.Fatal("failed to roundtrip *big.Int")
-	}
-
-	if one.World.Cmp(&oneBack.World) != 0 {
-		t.Fatal("failed to roundtrip big.Int")
-	}
-
-	list := map[string]*TestMe{
-		"hello": &TestMe{Hello: big.NewInt(10), World: *big.NewInt(101), Hi: 1},
-		"world": &TestMe{Hello: big.NewInt(9), World: *big.NewInt(901), Hi: 3},
-	}
-
-	bytes, err = DumpObject(list)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var listBack map[string]*TestMe
-	if err := DecodeInto(bytes, &listBack); err != nil {
-		t.Fatal(err)
-	}
-
-	t.Log(listBack["hello"])
-	t.Log(listBack["world"])
-
-	if list["hello"].Hello.Cmp(listBack["hello"].Hello) != 0 {
-		t.Fatalf("failed to roundtrip *big.Int: %s != %s", list["hello"].Hello, listBack["hello"].Hello)
-	}
-
-	if list["hello"].World.Cmp(&listBack["hello"].World) != 0 {
-		t.Fatalf("failed to roundtrip big.Int: %s != %s", &list["hello"].World, &listBack["hello"].World)
-	}
-
-	if list["world"].Hello.Cmp(listBack["world"].Hello) != 0 {
-		t.Fatalf("failed to roundtrip *big.Int: %s != %s", list["world"].Hello, listBack["world"].Hello)
-	}
-
-	if list["world"].World.Cmp(&listBack["world"].World) != 0 {
-		t.Fatalf("failed to roundtrip big.Int: %s != %s", &list["world"].World, &listBack["world"].World)
-	}
-
 }


### PR DESCRIPTION
Remove the big.Int custom atlas and tests from this repo so we can control the big.Int encoding from within the filecoin project. I'll re-introduce this custom atlas on the filecoin side along with a new release of this repo (before replacing it on the filecoin side with something LEB128-based).

This is work towards https://github.com/filecoin-project/go-filecoin/issues/340